### PR TITLE
Fixed missing h in Bryter URL

### DIFF
--- a/data/events/2020/talks/treat_yourself.yml
+++ b/data/events/2020/talks/treat_yourself.yml
@@ -28,7 +28,7 @@ speakers:
     position: "Software Developer"
     company:
       name: "BRYTER GmbH"
-      link: "ttps://bryter.io/"
+      link: "https://bryter.io/"
     links:
       - name: "Website"
         link: "https://www.programmiri.de/"


### PR DESCRIPTION
I noticed this small error while surfing the site and thought I'd send a PR :smiley: 